### PR TITLE
Redesign: clean dark dashboard aesthetic for EchoMe Resonance

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>EchoMe Conversation Hub</title>
-    <link href="/dist/output.css" rel="stylesheet" />
+    <title>EchoMe Resonance — Conversation Orchestration</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=JetBrains+Mono:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,82 +3,99 @@ import ConversationHub from './components/ConversationHub';
 import EmotionalSync from './components/EmotionalSync';
 
 function App() {
-  const [pro, setPro] = useState(false);
-  const [exportsUsed, setExportsUsed] = useState(0);
+  const [pro] = useState(false);
+  const [exportsUsed] = useState(0);
 
   const handlePro = () => {
     window.open('https://buy.stripe.com/00weVd16be835Cr57Q8Zq00', '_blank');
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-900 via-pink-900 to-indigo-900 p-4 md:p-8 overflow-hidden">
-      <div className="absolute inset-0 opacity-20 pointer-events-none">
-        <div className="absolute top-0 left-1/4 w-96 h-96 bg-cyan-500 rounded-full blur-3xl" />
-        <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-pink-500 rounded-full blur-3xl" />
-      </div>
-
-      <div className="container relative mx-auto max-w-7xl">
-        <div className="text-center mb-12">
-          <div className="inline-flex items-center gap-3 px-5 py-2 rounded-full border border-cyan-400/20 bg-cyan-400/10 mb-6">
-            <span className="w-3 h-3 rounded-full bg-cyan-300 animate-pulse" />
-            <span className="text-cyan-200 text-sm tracking-widest uppercase">
-              emotionalSync active
-            </span>
+    <div className="min-h-screen bg-surface font-sans">
+      {/* Top nav */}
+      <header className="border-b border-border px-6 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {/* Logo mark */}
+          <div className="w-6 h-6 rounded bg-accent flex items-center justify-center">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <circle cx="7" cy="7" r="5" stroke="black" strokeWidth="2" />
+              <circle cx="7" cy="7" r="2" fill="black" />
+            </svg>
           </div>
-
-          <h1 className="text-5xl md:text-7xl font-black bg-gradient-to-r from-cyan-300 via-pink-300 to-indigo-300 bg-clip-text text-transparent mb-4">
-            EchoMe Resonance
-          </h1>
-
-          <p className="text-xl text-white/80 max-w-3xl mx-auto leading-relaxed">
-            Emotionally synchronized resonance architecture integrating QRFT-inspired coherence,
-            contextual memory weighting, and adaptive interaction dynamics.
-          </p>
+          <span className="text-sm font-semibold text-foreground tracking-tight">EchoMe</span>
+          <span className="text-border">/</span>
+          <span className="text-sm text-muted">Resonance</span>
         </div>
 
-        <div className="grid grid-cols-1 xl:grid-cols-3 gap-8 items-start">
-          <div className="xl:col-span-2">
-            {exportsUsed < 3 || pro ? (
+        <div className="flex items-center gap-3">
+          {/* Status pill */}
+          <div className="flex items-center gap-2 px-3 py-1 rounded-full border border-accent/30 bg-accent/5">
+            <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse" />
+            <span className="text-xs text-accent font-mono tracking-widest uppercase">emotionalSync</span>
+          </div>
+
+          {!pro && (
+            <button
+              onClick={handlePro}
+              className="text-xs font-semibold px-3 py-1.5 rounded-md bg-accent text-black hover:bg-accent/90 transition-colors"
+            >
+              Upgrade to Pro
+            </button>
+          )}
+        </div>
+      </header>
+
+      {/* Page header */}
+      <div className="border-b border-border px-6 py-6">
+        <h1 className="text-xl font-semibold text-foreground">Conversation Orchestration</h1>
+        <p className="text-sm text-muted mt-1 max-w-xl leading-relaxed">
+          QRFT-inspired coherence across multi-model AI sessions with contextual memory weighting
+          and adaptive emotional synchronization.
+        </p>
+      </div>
+
+      {/* Main content */}
+      <main className="px-6 py-6">
+        {exportsUsed < 3 || pro ? (
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6 items-start">
+            <div className="xl:col-span-2">
               <ConversationHub />
-            ) : (
-              <div className="flex flex-col items-center justify-center min-h-[400px] bg-white/5 backdrop-blur-xl rounded-3xl p-12 border border-white/20">
-                <div className="text-center">
-                  <div className="w-24 h-24 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center mx-auto mb-8 text-3xl">
-                    🔒
-                  </div>
-
-                  <h2 className="text-3xl font-bold text-white mb-6">
-                    Go Pro for Unlimited
-                  </h2>
-
-                  <p className="text-xl text-white/80 mb-8 max-w-md">
-                    Continue creating resonance magic with unlimited exports
-                  </p>
-
-                  <button
-                    onClick={handlePro}
-                    className="bg-gradient-to-r from-purple-500 to-pink-500 text-white px-10 py-5 rounded-2xl font-bold text-xl shadow-2xl hover:scale-105 transition-all duration-300"
-                  >
-                    🚀 Unlock Pro $9.99/mo
-                  </button>
-
-                  <p className="text-white/60 mt-4 text-sm">Cancel anytime</p>
-                </div>
-              </div>
-            )}
+            </div>
+            <div>
+              <EmotionalSync />
+            </div>
           </div>
-
-          <div>
-            <EmotionalSync />
+        ) : (
+          /* Paywall */
+          <div className="flex flex-col items-center justify-center min-h-[400px] border border-border rounded-xl p-12 bg-card">
+            <div className="w-10 h-10 rounded-full border border-border flex items-center justify-center mb-6">
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+                <rect x="4" y="8" width="10" height="8" rx="1" stroke="currentColor" strokeWidth="1.5" className="text-muted" />
+                <path d="M6 8V6a3 3 0 0 1 6 0v2" stroke="currentColor" strokeWidth="1.5" className="text-muted" />
+              </svg>
+            </div>
+            <h2 className="text-lg font-semibold text-foreground mb-2">Unlimited exports with Pro</h2>
+            <p className="text-sm text-muted mb-6 text-center max-w-sm leading-relaxed">
+              You&apos;ve used your 3 free exports. Upgrade to Pro for unlimited conversation exports
+              and advanced resonance features.
+            </p>
+            <button
+              onClick={handlePro}
+              className="px-6 py-2.5 bg-accent text-black text-sm font-semibold rounded-md hover:bg-accent/90 transition-colors"
+            >
+              Unlock Pro — $9.99 / mo
+            </button>
+            <p className="text-xs text-muted mt-3">Cancel anytime</p>
           </div>
-        </div>
+        )}
+      </main>
 
-        <div className="text-center mt-16 pt-12 border-t border-white/10">
-          <p className="text-white/50 tracking-wide">
-            © 2026 Rod's AI Consulting LLC • EchoMe • QRFT • emotionalSync
-          </p>
-        </div>
-      </div>
+      {/* Footer */}
+      <footer className="border-t border-border px-6 py-4 mt-8">
+        <p className="text-xs text-muted">
+          © 2026 Rod&apos;s AI Consulting LLC &nbsp;·&nbsp; EchoMe &nbsp;·&nbsp; QRFT &nbsp;·&nbsp; emotionalSync
+        </p>
+      </footer>
     </div>
   );
 }

--- a/src/components/ConversationHub.jsx
+++ b/src/components/ConversationHub.jsx
@@ -2,6 +2,41 @@ import React, { useState, useEffect } from 'react';
 
 const models = ['ChatGPT-4', 'Claude-3', 'Gemini-Pro'];
 
+const MODEL_COLORS = {
+  'ChatGPT-4': 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
+  'Claude-3':  'bg-orange-500/20 text-orange-400 border-orange-500/30',
+  'Gemini-Pro':'bg-sky-500/20 text-sky-400 border-sky-500/30',
+};
+
+const MODEL_DOT = {
+  'ChatGPT-4': 'bg-emerald-400',
+  'Claude-3':  'bg-orange-400',
+  'Gemini-Pro':'bg-sky-400',
+};
+
+function Section({ title, children }) {
+  return (
+    <section className="border border-border rounded-xl bg-card overflow-hidden">
+      <div className="px-4 py-3 border-b border-border bg-surface">
+        <h3 className="text-xs font-semibold text-muted uppercase tracking-widest">{title}</h3>
+      </div>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+function Field({ label, children }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-xs font-medium text-muted">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+const inputCls =
+  'w-full bg-surface border border-border rounded-md px-3 py-2 text-sm text-foreground placeholder:text-muted/50 focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors';
+
 function ConversationHub() {
   const [selectedModel, setSelectedModel] = useState(models[0]);
   const [conversationType, setConversationType] = useState('');
@@ -13,21 +48,20 @@ function ConversationHub() {
   const [history, setHistory] = useState([]);
   const [metrics, setMetrics] = useState({
     'ChatGPT-4': { times: [], success: 0 },
-    'Claude-3': { times: [], success: 0 },
-    'Gemini-Pro': { times: [], success: 0 },
+    'Claude-3':  { times: [], success: 0 },
+    'Gemini-Pro':{ times: [], success: 0 },
   });
   const [context, setContext] = useState('');
 
   useEffect(() => {
     let interval;
     if (running && completedRounds < numRounds) {
-      interval = setInterval(() => {
-        runRound();
-      }, 1000);
+      interval = setInterval(() => { runRound(); }, 1000);
     } else if (completedRounds >= numRounds) {
       setRunning(false);
     }
     return () => clearInterval(interval);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [running, completedRounds, numRounds]);
 
   const runRound = () => {
@@ -56,35 +90,15 @@ function ConversationHub() {
     setHistory([]);
     setMetrics({
       'ChatGPT-4': { times: [], success: 0 },
-      'Claude-3': { times: [], success: 0 },
-      'Gemini-Pro': { times: [], success: 0 },
+      'Claude-3':  { times: [], success: 0 },
+      'Gemini-Pro':{ times: [], success: 0 },
     });
   };
 
   const injectContext = () => {
-    setHistory((h) => [...h, { round: 'context', model: 'inject', message: context }]);
+    if (!context.trim()) return;
+    setHistory((h) => [...h, { round: 'ctx', model: 'system', message: context }]);
     setContext('');
-  };
-
-  const exportJSON = () => {
-    const blob = new Blob([JSON.stringify(history, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    download(url, 'conversation.json');
-  };
-
-  const exportCSV = () => {
-    const header = 'round,model,time,success,context';
-    const rows = history.map((h) => `${h.round},${h.model},${h.time},${h.success},${h.context || ''}`);
-    const blob = new Blob([header + '\n' + rows.join('\n')], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    download(url, 'conversation.csv');
-  };
-
-  const exportPDF = () => {
-    const text = history.map((h) => JSON.stringify(h)).join('\n');
-    const blob = new Blob([text], { type: 'application/pdf' });
-    const url = URL.createObjectURL(blob);
-    download(url, 'conversation.pdf');
   };
 
   const download = (url, filename) => {
@@ -95,110 +109,244 @@ function ConversationHub() {
     URL.revokeObjectURL(url);
   };
 
-  const averageTime = (times) => {
-    if (!times.length) return 0;
-    return (times.reduce((a, b) => a + b, 0) / times.length).toFixed(0);
+  const exportJSON = () => {
+    const blob = new Blob([JSON.stringify(history, null, 2)], { type: 'application/json' });
+    download(URL.createObjectURL(blob), 'conversation.json');
   };
 
+  const exportCSV = () => {
+    const header = 'round,model,time,success,context';
+    const rows = history.map((h) => `${h.round},${h.model},${h.time},${h.success},${h.context || ''}`);
+    const blob = new Blob([header + '\n' + rows.join('\n')], { type: 'text/csv' });
+    download(URL.createObjectURL(blob), 'conversation.csv');
+  };
+
+  const exportPDF = () => {
+    const text = history.map((h) => JSON.stringify(h)).join('\n');
+    const blob = new Blob([text], { type: 'application/pdf' });
+    download(URL.createObjectURL(blob), 'conversation.pdf');
+  };
+
+  const avg = (times) =>
+    times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(0) : '—';
+
+  const progress = numRounds > 0 ? Math.min((completedRounds / numRounds) * 100, 100) : 0;
+
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label className="block mb-1 font-semibold">AI Model</label>
-          <select
-            className="w-full p-2 border rounded"
-            value={selectedModel}
-            onChange={(e) => setSelectedModel(e.target.value)}
-          >
-            {models.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label className="block mb-1 font-semibold">Conversation Type</label>
-          <input
-            className="w-full p-2 border rounded"
-            value={conversationType}
-            onChange={(e) => setConversationType(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-semibold">Topic</label>
-          <input
-            className="w-full p-2 border rounded"
-            value={topic}
-            onChange={(e) => setTopic(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-semibold">Number of Rounds</label>
-          <input
-            type="number"
-            className="w-full p-2 border rounded"
-            value={numRounds}
-            onChange={(e) => setNumRounds(Number(e.target.value))}
-          />
-        </div>
-        <div className="md:col-span-2">
-          <label className="block mb-1 font-semibold">Participant Order (comma separated)</label>
-          <input
-            className="w-full p-2 border rounded"
-            value={participantOrder}
-            onChange={(e) => setParticipantOrder(e.target.value)}
-          />
-        </div>
-      </div>
+    <div className="space-y-4">
+      {/* Configuration */}
+      <Section title="Configuration">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Field label="AI Model">
+            <select
+              className={inputCls}
+              value={selectedModel}
+              onChange={(e) => setSelectedModel(e.target.value)}
+            >
+              {models.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </Field>
 
-      <div className="flex items-center space-x-4">
-        <button className="px-4 py-2 bg-green-500 text-white rounded" onClick={start} disabled={running}>
-          Start
-        </button>
-        <button className="px-4 py-2 bg-yellow-500 text-white rounded" onClick={pause} disabled={!running}>
-          Pause
-        </button>
-        <button className="px-4 py-2 bg-red-500 text-white rounded" onClick={reset}>
-          Reset
-        </button>
-        <span>Rounds Completed: {completedRounds}</span>
-      </div>
+          <Field label="Conversation Type">
+            <input
+              className={inputCls}
+              placeholder="e.g. debate, brainstorm…"
+              value={conversationType}
+              onChange={(e) => setConversationType(e.target.value)}
+            />
+          </Field>
 
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Metrics</h2>
-        {models.map((m) => (
-          <div key={m} className="p-2 border rounded">
-            <div className="font-semibold">{m}</div>
-            <div>Avg Response Time: {averageTime(metrics[m].times)} ms</div>
-            <div>Success Rate: {(metrics[m].success * 100).toFixed(0)}%</div>
+          <Field label="Topic">
+            <input
+              className={inputCls}
+              placeholder="Enter a topic…"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+            />
+          </Field>
+
+          <Field label="Number of Rounds">
+            <input
+              type="number"
+              min="1"
+              className={inputCls}
+              value={numRounds}
+              onChange={(e) => setNumRounds(Number(e.target.value))}
+            />
+          </Field>
+
+          <Field label="Participant Order (comma-separated)" >
+            <div className="sm:col-span-2">
+              <input
+                className={inputCls}
+                value={participantOrder}
+                onChange={(e) => setParticipantOrder(e.target.value)}
+              />
+            </div>
+          </Field>
+        </div>
+      </Section>
+
+      {/* Controls + Progress */}
+      <Section title="Session Controls">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-3 flex-wrap">
+            <button
+              onClick={start}
+              disabled={running}
+              className="flex items-center gap-2 px-4 py-2 rounded-md bg-accent text-black text-sm font-semibold disabled:opacity-40 hover:bg-accent/90 transition-colors"
+            >
+              {/* Play icon */}
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+                <path d="M2 1.5l8 4.5-8 4.5V1.5z" />
+              </svg>
+              Start
+            </button>
+
+            <button
+              onClick={pause}
+              disabled={!running}
+              className="flex items-center gap-2 px-4 py-2 rounded-md border border-border text-sm text-foreground disabled:opacity-40 hover:bg-card transition-colors"
+            >
+              {/* Pause icon */}
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+                <rect x="2" y="1" width="3" height="10" rx="1" />
+                <rect x="7" y="1" width="3" height="10" rx="1" />
+              </svg>
+              Pause
+            </button>
+
+            <button
+              onClick={reset}
+              className="flex items-center gap-2 px-4 py-2 rounded-md border border-border text-sm text-foreground hover:bg-card transition-colors"
+            >
+              {/* Reset icon */}
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+                <path d="M10 6A4 4 0 1 1 6 2" strokeLinecap="round" />
+                <path d="M6 0l2 2-2 2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              Reset
+            </button>
+
+            <div className="ml-auto flex items-center gap-2 text-sm">
+              <span className="text-muted">Round</span>
+              <span className="font-mono text-foreground font-semibold">
+                {completedRounds} / {numRounds}
+              </span>
+            </div>
           </div>
+
+          {/* Progress bar */}
+          <div className="h-1.5 w-full rounded-full bg-border overflow-hidden">
+            <div
+              className="h-full rounded-full bg-accent transition-all duration-500"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </Section>
+
+      {/* Metrics */}
+      <Section title="Model Metrics">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {models.map((m) => (
+            <div key={m} className="rounded-lg border border-border bg-surface p-3 flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <span className={`w-2 h-2 rounded-full ${MODEL_DOT[m]}`} />
+                <span className="text-xs font-semibold text-foreground">{m}</span>
+              </div>
+              <div className="flex flex-col gap-1">
+                <div className="flex justify-between text-xs">
+                  <span className="text-muted">Avg Response</span>
+                  <span className="font-mono text-foreground">{avg(metrics[m].times)} ms</span>
+                </div>
+                <div className="flex justify-between text-xs">
+                  <span className="text-muted">Success Rate</span>
+                  <span className="font-mono text-foreground">
+                    {metrics[m].times.length ? `${(metrics[m].success * 100).toFixed(0)}%` : '—'}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      {/* Conversation Log */}
+      {history.length > 0 && (
+        <Section title="Conversation Log">
+          <div className="max-h-64 overflow-y-auto space-y-1 font-mono text-xs">
+            {history.map((h, i) => (
+              <div
+                key={i}
+                className={`flex items-start gap-3 px-3 py-2 rounded-md ${
+                  h.model === 'system'
+                    ? 'bg-accent/5 border border-accent/20'
+                    : h.success === false
+                    ? 'bg-red-500/5 border border-red-500/20'
+                    : 'bg-surface'
+                }`}
+              >
+                <span className="text-muted shrink-0 w-8 text-right">
+                  {h.model === 'system' ? 'ctx' : `#${h.round}`}
+                </span>
+                {h.model !== 'system' ? (
+                  <>
+                    <span className={`shrink-0 px-1.5 py-0.5 rounded border text-[10px] font-semibold ${MODEL_COLORS[h.model] || 'bg-muted/20 text-muted border-border'}`}>
+                      {h.model}
+                    </span>
+                    <span className="text-muted">{h.time}ms</span>
+                    <span className={h.success ? 'text-emerald-400' : 'text-red-400'}>
+                      {h.success ? 'ok' : 'fail'}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-accent">{h.message}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Context Injection */}
+      <Section title="Inject Context">
+        <div className="flex gap-2">
+          <textarea
+            rows={3}
+            className={`${inputCls} resize-none flex-1`}
+            placeholder="Type context to inject into the next round…"
+            value={context}
+            onChange={(e) => setContext(e.target.value)}
+          />
+          <button
+            onClick={injectContext}
+            className="px-4 py-2 rounded-md bg-card border border-border text-sm text-foreground hover:border-accent/50 transition-colors self-start"
+          >
+            Inject
+          </button>
+        </div>
+      </Section>
+
+      {/* Exports */}
+      <section className="flex items-center gap-2 flex-wrap">
+        <span className="text-xs text-muted mr-1">Export as:</span>
+        {[['JSON', exportJSON], ['CSV', exportCSV], ['PDF', exportPDF]].map(([label, fn]) => (
+          <button
+            key={label}
+            onClick={fn}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border text-xs text-muted hover:text-foreground hover:border-accent/40 transition-colors font-mono"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+              <path d="M6 1v7M3.5 5.5L6 8l2.5-2.5" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M1 9v1a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V9" strokeLinecap="round" />
+            </svg>
+            {label}
+          </button>
         ))}
-      </div>
-
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Inject Context</h2>
-        <textarea
-          className="w-full p-2 border rounded"
-          value={context}
-          onChange={(e) => setContext(e.target.value)}
-        />
-        <button className="px-4 py-2 bg-blue-500 text-white rounded" onClick={injectContext}>
-          Inject
-        </button>
-      </div>
-
-      <div className="space-x-4">
-        <button className="px-4 py-2 bg-gray-800 text-white rounded" onClick={exportJSON}>
-          Export JSON
-        </button>
-        <button className="px-4 py-2 bg-gray-800 text-white rounded" onClick={exportCSV}>
-          Export CSV
-        </button>
-        <button className="px-4 py-2 bg-gray-800 text-white rounded" onClick={exportPDF}>
-          Export PDF
-        </button>
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/components/EmotionalSync.jsx
+++ b/src/components/EmotionalSync.jsx
@@ -1,13 +1,18 @@
 import React, { useMemo, useState } from 'react';
 
-const states = [
-  'Calm',
-  'Focused',
-  'Curious',
-  'Overloaded',
-  'Creative',
-  'Reflective'
-];
+const states = ['Calm', 'Focused', 'Curious', 'Overloaded', 'Creative', 'Reflective'];
+
+const STATE_ACCENT = {
+  Calm:       'text-sky-400',
+  Focused:    'text-accent',
+  Curious:    'text-amber-400',
+  Overloaded: 'text-red-400',
+  Creative:   'text-violet-400',
+  Reflective: 'text-emerald-400',
+};
+
+const inputCls =
+  'w-full bg-surface border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent/50 focus:border-accent/50 transition-colors';
 
 function EmotionalSync() {
   const [userState, setUserState] = useState('Focused');
@@ -19,82 +24,124 @@ function EmotionalSync() {
     return Math.max(0, Math.min(1, sync)).toFixed(3);
   }, [resonance]);
 
+  const coherenceNum = parseFloat(coherence);
+  const coherencePct = Math.round(coherenceNum * 100);
+
+  // Color the coherence score by quality
+  const coherenceColor =
+    coherenceNum >= 0.8 ? 'text-emerald-400' :
+    coherenceNum >= 0.5 ? 'text-accent' :
+    'text-red-400';
+
   return (
-    <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-3xl p-6 text-white shadow-2xl">
-      <div className="flex items-center justify-between mb-6">
+    <div className="border border-border rounded-xl bg-card overflow-hidden">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-border bg-surface flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold bg-gradient-to-r from-pink-400 to-cyan-400 bg-clip-text text-transparent">
-            emotionalSync
-          </h2>
-          <p className="text-white/60 text-sm mt-1">
-            Resonance-aligned emotional coherence layer
+          <h2 className="text-xs font-semibold text-muted uppercase tracking-widest">emotionalSync</h2>
+          <p className="text-[11px] text-muted/60 mt-0.5">Resonance-aligned coherence layer</p>
+        </div>
+        <div className="text-right">
+          <div className="text-[10px] text-muted uppercase tracking-widest mb-0.5">Coherence</div>
+          <div className={`text-2xl font-black font-mono ${coherenceColor}`}>{coherence}</div>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-5">
+        {/* State selectors */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-muted">User State</label>
+            <select
+              value={userState}
+              onChange={(e) => setUserState(e.target.value)}
+              className={inputCls}
+            >
+              {states.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+            <div className={`text-xs font-semibold ${STATE_ACCENT[userState]}`}>{userState}</div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-muted">System State</label>
+            <select
+              value={systemState}
+              onChange={(e) => setSystemState(e.target.value)}
+              className={inputCls}
+            >
+              {states.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+            <div className={`text-xs font-semibold ${STATE_ACCENT[systemState]}`}>{systemState}</div>
+          </div>
+        </div>
+
+        {/* Resonance slider */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-muted">Entanglement Signature</span>
+            <span className="text-xs font-mono text-foreground">{resonance.toFixed(3)}</span>
+          </div>
+
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.001"
+            value={resonance}
+            onChange={(e) => setResonance(Number(e.target.value))}
+            className="w-full accent-[var(--color-accent)] cursor-pointer"
+            aria-label="Entanglement Signature"
+          />
+
+          <div className="flex justify-between text-[10px] text-muted">
+            <span>0.000</span>
+            <span>Optimal: 0.425</span>
+            <span>1.000</span>
+          </div>
+        </div>
+
+        {/* Coherence bar */}
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted">Synchronization Quality</span>
+            <span className={`font-mono font-semibold ${coherenceColor}`}>{coherencePct}%</span>
+          </div>
+          <div className="h-1.5 w-full rounded-full bg-border overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${
+                coherenceNum >= 0.8 ? 'bg-emerald-400' :
+                coherenceNum >= 0.5 ? 'bg-accent' :
+                'bg-red-400'
+              }`}
+              style={{ width: `${coherencePct}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Output description */}
+        <div className="rounded-lg border border-accent/20 bg-accent/5 p-3">
+          <div className="text-[10px] uppercase tracking-widest text-accent mb-1.5 font-semibold">
+            Sync Output
+          </div>
+          <p className="text-xs text-muted leading-relaxed">
+            emotionalSync maps resonance between the user and system, preserving agency while
+            adapting cadence, tone, pacing, and contextual weighting.
           </p>
         </div>
 
-        <div className="text-right">
-          <div className="text-xs text-white/50 uppercase tracking-widest">Coherence</div>
-          <div className="text-3xl font-black text-cyan-300">{coherence}</div>
+        {/* State delta */}
+        <div className="flex items-center gap-2 text-xs">
+          <span className={`font-semibold ${STATE_ACCENT[userState]}`}>{userState}</span>
+          <svg width="14" height="8" viewBox="0 0 14 8" fill="none" aria-hidden="true">
+            <path d="M1 4h12M9 1l3 3-3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" className="text-border" />
+          </svg>
+          <span className={`font-semibold ${STATE_ACCENT[systemState]}`}>{systemState}</span>
+          <span className="ml-auto text-muted font-mono">{resonance.toFixed(3)}</span>
         </div>
-      </div>
-
-      <div className="grid md:grid-cols-2 gap-4 mb-6">
-        <div>
-          <label className="block text-sm text-white/70 mb-2">User State</label>
-          <select
-            value={userState}
-            onChange={(e) => setUserState(e.target.value)}
-            className="w-full bg-black/20 border border-white/10 rounded-xl p-3"
-          >
-            {states.map((state) => (
-              <option key={state} value={state} className="text-black">
-                {state}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label className="block text-sm text-white/70 mb-2">System State</label>
-          <select
-            value={systemState}
-            onChange={(e) => setSystemState(e.target.value)}
-            className="w-full bg-black/20 border border-white/10 rounded-xl p-3"
-          >
-            {states.map((state) => (
-              <option key={state} value={state} className="text-black">
-                {state}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-
-      <div className="mb-4">
-        <div className="flex justify-between text-sm text-white/70 mb-2">
-          <span>Entanglement Signature</span>
-          <span>{resonance.toFixed(3)}</span>
-        </div>
-
-        <input
-          type="range"
-          min="0"
-          max="1"
-          step="0.001"
-          value={resonance}
-          onChange={(e) => setResonance(Number(e.target.value))}
-          className="w-full"
-        />
-      </div>
-
-      <div className="mt-6 rounded-2xl border border-cyan-500/20 bg-cyan-500/5 p-4">
-        <div className="text-sm uppercase tracking-wider text-cyan-300 mb-2">
-          Synchronization Output
-        </div>
-
-        <p className="text-white/80 leading-relaxed">
-          emotionalSync dynamically maps emotional resonance between the user and the system,
-          preserving agency while adapting cadence, tone, pacing, and contextual weighting.
-        </p>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,58 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    /* Dark terminal palette */
+    --color-surface:      #0a0a0a;   /* page background */
+    --color-card:         #111111;   /* card / panel */
+    --color-border:       #222222;   /* borders / dividers */
+    --color-foreground:   #ededed;   /* primary text */
+    --color-muted:        #777777;   /* secondary / label text */
+    --color-accent:       #00e5c4;   /* brand accent — electric teal */
+  }
+
+  html {
+    background-color: var(--color-surface);
+  }
+
+  body {
+    color: var(--color-foreground);
+    background-color: var(--color-surface);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Native select / option dark reset */
+  select option {
+    background-color: #1a1a1a;
+    color: #ededed;
+  }
+
+  /* Range input track */
+  input[type='range'] {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--color-border);
+    appearance: none;
+    -webkit-appearance: none;
+    cursor: pointer;
+  }
+  input[type='range']::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    border: 2px solid var(--color-surface);
+    cursor: pointer;
+  }
+  input[type='range']::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    border: 2px solid var(--color-surface);
+    cursor: pointer;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,20 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        surface:    'var(--color-surface)',
+        card:       'var(--color-card)',
+        border:     'var(--color-border)',
+        foreground: 'var(--color-foreground)',
+        muted:      'var(--color-muted)',
+        accent:     'var(--color-accent)',
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary

Complete visual redesign of the EchoMe Resonance UI, replacing the gradient blob / glassmorphism aesthetic with a clean, dark, terminal-inspired dashboard look.

## Changes

### Design System (`src/index.css`, `tailwind.config.js`)
- Defined 5 semantic design tokens: `surface`, `card`, `border`, `foreground`, `muted`, `accent` (electric teal `#00e5c4`)
- Custom range input styles for the resonance slider
- Added Inter (UI) + JetBrains Mono (data/code) via Google Fonts

### `src/App.jsx`
- Replaced full-bleed gradient background with a `bg-surface` shell
- Proper `<header>` with logo mark, nav breadcrumb, status pill, and Pro upgrade CTA
- Structured page header with title + description
- Cleaner paywall state using proper SVG lock icon (no emoji)

### `src/components/ConversationHub.jsx`
- Sectioned layout using a reusable `<Section>` card component
- Styled form fields with consistent `<Field>` wrapper
- Progress bar for round completion
- Color-coded conversation log with per-model badges (emerald/orange/sky)
- Export buttons with SVG download icon

### `src/components/EmotionalSync.jsx`
- Coherence score colored by quality threshold (emerald/teal/red)
- Synchronization quality progress bar
- Per-state accent colors for User and System state selectors
- State delta arrow indicator
- Removed gradient text in favor of themed tokens